### PR TITLE
Add instrument session context

### DIFF
--- a/src/components/PlanParameters.tsx
+++ b/src/components/PlanParameters.tsx
@@ -8,6 +8,7 @@ import {
 import sanitizeSchema from "../utils/schema";
 import type { Plan } from "../utils/api";
 import RunPlanButton from "./RunPlanButton";
+import { useInstrumentSession } from "../context/InstrumentSessionContext";
 
 type PlanParametersProps = {
   plan: Plan;
@@ -20,7 +21,7 @@ const PlanParameters: React.FC<PlanParametersProps> = (
 
   // const renderers = materialRenderers;
   const [planParameters, setPlanParameters] = useState({});
-  const [instrumentSession, setInstrumentSession] = useState("");
+  const {instrumentSession, setInstrumentSession} = useInstrumentSession();
 
   return (
     <Box>
@@ -41,6 +42,7 @@ const PlanParameters: React.FC<PlanParametersProps> = (
       <TextField
         id="instrumentSession"
         label="Instrument Session"
+        defaultValue={instrumentSession}
         onChange={e => setInstrumentSession(e.target.value)}
       ></TextField>
       <Box sx={{ mt: 2 }}>

--- a/src/components/SpectroscopyForm.tsx
+++ b/src/components/SpectroscopyForm.tsx
@@ -3,6 +3,7 @@ import { Box, TextField } from "@mui/material";
 import NumberTextField from "./NumberTextField";
 import RunPlanButton from "./RunPlanButton";
 import RawSpectroscopyData from "./RawSpectroscopyData";
+import { useInstrumentSession } from "../context/InstrumentSessionContext";
 
 export type SpectroscopyFormData = {
   numbers_of_points: number;
@@ -20,7 +21,8 @@ function SpectroscopyForm() {
     grid_origin_y: 0.0,
     exposure_time: 0.1,
   });
-  const [instrumentSession, setInstrumentSession] = useState("");
+
+  const {instrumentSession, setInstrumentSession} = useInstrumentSession();
 
   return (
     <Box
@@ -82,6 +84,7 @@ function SpectroscopyForm() {
           fullWidth
           id="instrumentSession"
           label="Instrument Session"
+          defaultValue={instrumentSession}
           onChange={e => setInstrumentSession(e.target.value)}
         />
       </Box>

--- a/src/context/InstrumentSessionContext.tsx
+++ b/src/context/InstrumentSessionContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+type InstrumentSessionContextType = {
+  instrumentSession: string,
+  setInstrumentSession: (session: string) => void;
+}
+
+const InstrumentSessionContext = createContext<InstrumentSessionContextType | undefined>(undefined);
+
+const STORAGE_KEY = "instrument-session-id"
+
+export const InstrumentSessionProvider = ({
+  children,
+  defaultSessionId = "0-0",
+}: { children: ReactNode; defaultSessionId?: string }) => {
+
+  const [instrumentSession, setInstrumentSession] = useState<string>(() => {
+    return localStorage.getItem(STORAGE_KEY) ?? defaultSessionId;
+  });
+
+  useEffect(() => {localStorage.setItem(STORAGE_KEY, instrumentSession)}, [instrumentSession]);
+
+  return (
+    <InstrumentSessionContext.Provider value={{ instrumentSession, setInstrumentSession}}>
+      {children}
+    </InstrumentSessionContext.Provider>
+  );
+};
+
+export const useInstrumentSession = () => {
+  const context = useContext(InstrumentSessionContext);
+  if (!context) throw new Error("useInstrumentSession must be used within InstrumentSessionProvider");
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider, DiamondTheme } from "@diamondlightsource/sci-react-ui";
 import JsonFormsPlans from "./routes/Plans.tsx";
 import Dashboard from "./routes/Dashboard.tsx";
 import Spectroscopy from "./routes/Spectroscopy.tsx";
+import { InstrumentSessionProvider } from "./context/InstrumentSessionContext.tsx";
 
 declare global {
   interface Window {
@@ -20,6 +21,8 @@ async function enableMocking() {
     return worker.start();
   }
 }
+
+
 
 const router = createBrowserRouter([
   {
@@ -40,7 +43,9 @@ enableMocking().then(() => {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <ThemeProvider theme={DiamondTheme} defaultMode="light">
-        <RouterProvider router={router} />
+        <InstrumentSessionProvider defaultSessionId="cm40661-1">
+          <RouterProvider router={router} />
+        </InstrumentSessionProvider>
       </ThemeProvider>
     </StrictMode>,
   );


### PR DESCRIPTION
This change adds instrument session context and provider, which internally caches and retrieves the state using localStorage. Default instrument session can be passed as prop to the provider.