### PR TITLE
Update instrument session numbers for 2026

### DIFF
--- a/src/context/instrumentSession/InstrumentSessionProvider.tsx
+++ b/src/context/instrumentSession/InstrumentSessionProvider.tsx
@@ -5,7 +5,7 @@ const STORAGE_KEY = "instrument-session-id";
 
 export const InstrumentSessionProvider = ({
   children,
-  defaultSessionId = "cm40661-6",
+  defaultSessionId = "cm44191-1",
 }: {
   children: ReactNode;
   defaultSessionId?: string;

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -44,7 +44,15 @@ function Dashboard() {
             </Button>
           </Stack>
           {/* <InstrumentSessionView sessionsList={GetInstrumentSessions()} /> */}
-          <InstrumentSessionView sessionsList={["cm40661-6"]} />
+          <InstrumentSessionView
+            sessionsList={[
+              "cm44191-1",
+              "cm44191-2",
+              "cm44191-3",
+              "cm44191-4",
+              "cm44191-5",
+            ]}
+          />
         </Stack>
       </Container>
     </>


### PR DESCRIPTION
Instrument sessions exist for 2026, and all session numbers all have been added to the default session list on the dashboard (with the first session now being the default session).

File structure does not yet exist (still chasing this), but a valid scan number can be retrieved from numtracker for the first session.